### PR TITLE
Update `SegVec` sort API

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -338,7 +338,7 @@ fn test_segvec_sort() {
         }
 
         // sorted descending
-        v.sort();
+        v.sort_unstable();
         if i > 0 {
             for j in 0..i - 1 {
                 assert!(&v[j] <= &v[j + 1], "{:?}", v);


### PR DESCRIPTION
1. Rename `SegVec::sort*` to `SegVec::sort_unstable*` to indicate that it is an unstable sort, to be more in line with the standard library.
2. Update the signature of the function required by `SegVec::sort_unstable_by` to return a `std::cmp::Ordering` rather than a `bool`

Partially addresses #3 