### PR TITLE
Remove phantomdata/Stateful MemConfig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ thin-segments = ["thin-vec"]
 [[bench]]
 name = "segvec_benchmark"
 harness = false
+
+[[bench]]
+name = "segvec_benchmark2"
+harness = false

--- a/benches/segvec_benchmark.rs
+++ b/benches/segvec_benchmark.rs
@@ -23,6 +23,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             }
         });
     });
+    group.bench_function("Proportional<1>", |b| {
+        b.iter_with_large_drop(|| {
+            let mut v: SegVec<i32, Proportional<1>> = SegVec::with_capacity(0);
+            for i in 0..N {
+                v.push(black_box(i));
+            }
+        });
+    });
     group.bench_function("Linear<1024>", |b| {
         b.iter_with_large_drop(|| {
             let mut v: SegVec<i32, Linear> = SegVec::with_capacity(0);

--- a/benches/segvec_benchmark2.rs
+++ b/benches/segvec_benchmark2.rs
@@ -1,0 +1,217 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use segvec::*;
+
+#[inline(always)]
+fn fast_prng(state: &mut u32) -> usize {
+    let rand = *state;
+    *state = rand << 1 ^ ((rand >> 30) & 1) ^ ((rand >> 2) & 1);
+    rand as usize
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    //const N: i32 = 10000;
+    const N: usize = 100000;
+    //const N: i32 = 1000000;
+
+    let mut group = c.benchmark_group("access/ordered");
+
+    group.bench_function("std Vec", |b| {
+        let mut v: Vec<usize> = Vec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        b.iter_with_large_drop(|| {
+            for i in 0..N {
+                _ = black_box(v.get(black_box(i)));
+            }
+        });
+    });
+
+    group.bench_function("SegVec/Linear<64>", |b| {
+        let mut v: SegVec<usize, Linear<64>> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        b.iter_with_large_drop(|| {
+            for i in 0..N {
+                _ = black_box(v.get(black_box(i)));
+            }
+        });
+    });
+
+    group.bench_function("SegVec/Proportional<1>", |b| {
+        let mut v: SegVec<usize, Proportional<1>> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        b.iter_with_large_drop(|| {
+            for i in 0..N {
+                _ = black_box(v.get(black_box(i)));
+            }
+        });
+    });
+
+    group.bench_function("SegVec", |b| {
+        let mut v: SegVec<usize> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        b.iter_with_large_drop(|| {
+            for i in 0..N {
+                _ = black_box(v.get(black_box(i)));
+            }
+        });
+    });
+
+    drop(group);
+    let mut group = c.benchmark_group("access/random");
+
+    group.bench_function("std Vec", |b| {
+        let mut v: Vec<usize> = Vec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                _ = black_box(v.get(fast_prng(&mut prng_state) % N));
+            }
+        });
+    });
+
+    group.bench_function("SegVec/Linear<64>", |b| {
+        let mut v: SegVec<usize, Linear<64>> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                _ = black_box(v.get(fast_prng(&mut prng_state) % N));
+            }
+        });
+    });
+
+    group.bench_function("SegVec/Proportional<1>", |b| {
+        let mut v: SegVec<usize, Proportional<1>> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                _ = black_box(v.get(fast_prng(&mut prng_state) % N));
+            }
+        });
+    });
+
+    group.bench_function("SegVec", |b| {
+        let mut v: SegVec<usize> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                _ = black_box(v.get(fast_prng(&mut prng_state) % N));
+            }
+        });
+    });
+
+    drop(group);
+    let mut group = c.benchmark_group("access/semirandom");
+
+    group.bench_function("std Vec", |b| {
+        let mut v: Vec<usize> = Vec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+        let mut index: usize = 0;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                index = (index + (fast_prng(&mut prng_state) % 1000))
+                    .saturating_sub(500)
+                    .min(N);
+                _ = black_box(v.get(index));
+            }
+        });
+    });
+
+    group.bench_function("SegVec/Linear<64>", |b| {
+        let mut v: SegVec<usize, Linear<64>> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+        let mut index: usize = 0;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                index = index
+                    .wrapping_add(fast_prng(&mut prng_state) % 1001)
+                    .wrapping_sub(500)
+                    % N;
+                _ = black_box(v.get(index));
+            }
+        });
+    });
+
+    group.bench_function("SegVec/Proportional<1>", |b| {
+        let mut v: SegVec<usize, Proportional<1>> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+        let mut index: usize = 0;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                index = index
+                    .wrapping_add(fast_prng(&mut prng_state) % 1001)
+                    .wrapping_sub(500)
+                    % N;
+                _ = black_box(v.get(index));
+            }
+        });
+    });
+
+    group.bench_function("SegVec", |b| {
+        let mut v: SegVec<usize> = SegVec::with_capacity(0);
+        for i in 0..N {
+            v.push(i);
+        }
+
+        let mut prng_state = 0xbabeface_u32;
+        let mut index: usize = 0;
+
+        b.iter_with_large_drop(|| {
+            for _ in 0..N {
+                index = index
+                    .wrapping_add(fast_prng(&mut prng_state) % 1001)
+                    .wrapping_sub(500)
+                    % N;
+                _ = black_box(v.get(index));
+            }
+        });
+    });
+}
+
+criterion_group!(benches2, criterion_benchmark);
+criterion_main!(benches2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ use std::default::Default;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::iter::{FromIterator, FusedIterator};
-use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Bound, Index, IndexMut, RangeBounds};
 
@@ -93,7 +92,7 @@ pub struct SegVec<T, C: MemConfig = Exponential<1>> {
     len: usize,
     capacity: usize,
     segments: detail::Segments<T>,
-    _config: PhantomData<C>,
+    config: C,
 }
 
 impl<T, C: MemConfig> SegVec<T, C> {
@@ -112,7 +111,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
             len: 0,
             capacity: 0,
             segments: detail::Segments::new(),
-            _config: PhantomData,
+            config: C::new(),
         }
     }
 
@@ -170,7 +169,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
     /// ```
     #[inline]
     pub fn capacity(&self) -> usize {
-        C::capacity(self.segments.len())
+        self.config.capacity(self.segments.len())
     }
 
     /// Reserve enough capacity to insert the given number of elements into the
@@ -201,9 +200,9 @@ impl<T, C: MemConfig> SegVec<T, C> {
     // do the real reserving in a cold path
     #[cold]
     fn reserve_cold(&mut self, min_cap: usize) {
-        let (segment, _) = C::segment_and_offset(min_cap - 1);
+        let (segment, _) = self.config.segment_and_offset(min_cap - 1);
         for i in self.segments.len()..=segment {
-            let seg_size = C::segment_size(i);
+            let seg_size = self.config.segment_size(i);
             self.segments.push(detail::Segment::with_capacity(seg_size));
         }
         self.capacity = self.capacity();
@@ -221,7 +220,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
     /// ```
     pub fn get(&self, index: usize) -> Option<&T> {
         if index < self.len {
-            let (seg, offset) = C::segment_and_offset(index);
+            let (seg, offset) = self.config.segment_and_offset(index);
             Some(&self.segments[seg][offset])
         } else {
             None
@@ -240,7 +239,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
     /// ```
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
         if index < self.len {
-            let (seg, offset) = C::segment_and_offset(index);
+            let (seg, offset) = self.config.segment_and_offset(index);
             Some(&mut self.segments[seg][offset])
         } else {
             None
@@ -260,7 +259,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
     /// - If the required capacity overflows `usize`
     pub fn push(&mut self, val: T) {
         self.reserve(1);
-        let (seg, _) = C::segment_and_offset(self.len);
+        let (seg, _) = self.config.segment_and_offset(self.len);
         self.segments[seg].push(val);
         self.len += 1;
     }
@@ -278,7 +277,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
         match self.len {
             0 => None,
             size => {
-                let (seg, offset) = C::segment_and_offset(size);
+                let (seg, offset) = self.config.segment_and_offset(size);
                 self.len -= 1;
                 match offset {
                     0 => self.segments[seg - 1].pop(),
@@ -305,7 +304,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
     /// ```
     pub fn truncate(&mut self, len: usize) {
         if len < self.capacity() {
-            let (seg, offset) = C::segment_and_offset(len);
+            let (seg, offset) = self.config.segment_and_offset(len);
             if offset == 0 {
                 self.segments.drain(seg..);
             } else {
@@ -423,7 +422,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
             return;
         }
         self.reserve(1);
-        let (mut seg_idx, mut seg_offset) = C::segment_and_offset(index);
+        let (mut seg_idx, mut seg_offset) = self.config.segment_and_offset(index);
         let mut displaced = val;
         loop {
             let maybe_displaced = unsafe {
@@ -495,7 +494,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
         if mem::size_of::<T>() == 0 {
             return self.pop().unwrap();
         }
-        let (mut seg_idx, seg_offset) = C::segment_and_offset(index);
+        let (mut seg_idx, seg_offset) = self.config.segment_and_offset(index);
         // SAFETY:
         // At this point, it is known that index points to a valid, non-zero-sized T in
         // the structure, and so it is safe to read a value of type T from this location
@@ -797,7 +796,7 @@ impl<T: Clone, C: MemConfig> Clone for SegVec<T, C> {
             len: self.len,
             capacity: self.capacity,
             segments: self.segments.clone(),
-            _config: PhantomData,
+            config: C::new(),
         }
     }
 }

--- a/src/mem_config.rs
+++ b/src/mem_config.rs
@@ -10,6 +10,8 @@ use num_integer::Roots;
 /// Configures the sizes of segments and how to index entries. `Linear`, `Proportional` and
 /// `Exponential` implement this trait.
 pub trait MemConfig {
+    fn new() -> Self;
+
     /// Called by ctors to assert that the configuration is valid.
     ///
     /// Some `MemConfig` implementations may put constraints on (const generic)
@@ -20,35 +22,39 @@ pub trait MemConfig {
     fn debug_assert_config();
 
     /// Takes the number of allocated segments, returns the total capacity.
-    fn capacity(segments: usize) -> usize;
+    fn capacity(&self, segments: usize) -> usize;
 
     /// Returns the size of the nth segment (starting at 0).
-    fn segment_size(segment: usize) -> usize;
+    fn segment_size(&self, segment: usize) -> usize;
 
     /// Translates a flat index into (segment, offset)
-    fn segment_and_offset(index: usize) -> (usize, usize);
+    fn segment_and_offset(&self, index: usize) -> (usize, usize);
 }
 
 /// Linear growth, all segments have the same (FACTOR) length.
 pub struct Linear<const FACTOR: usize = 1024>;
 impl<const FACTOR: usize> MemConfig for Linear<FACTOR> {
+    fn new() -> Self {
+        Self {}
+    }
+
     #[track_caller]
     fn debug_assert_config() {
         debug_assert_ne!(FACTOR, 0, "FACTOR must be greater than 0")
     }
 
     #[inline]
-    fn capacity(segments: usize) -> usize {
+    fn capacity(&self, segments: usize) -> usize {
         segments * FACTOR
     }
 
     #[inline]
-    fn segment_size(_segment: usize) -> usize {
+    fn segment_size(&self, _segment: usize) -> usize {
         FACTOR
     }
 
     #[inline]
-    fn segment_and_offset(index: usize) -> (usize, usize) {
+    fn segment_and_offset(&self, index: usize) -> (usize, usize) {
         (index / FACTOR, index % FACTOR)
     }
 }
@@ -56,40 +62,48 @@ impl<const FACTOR: usize> MemConfig for Linear<FACTOR> {
 /// Proportional growth, each segment is segment_number*FACTOR sized.
 pub struct Proportional<const FACTOR: usize>;
 impl<const FACTOR: usize> MemConfig for Proportional<FACTOR> {
+    fn new() -> Self {
+        Self {}
+    }
+
     #[track_caller]
     fn debug_assert_config() {
         debug_assert_ne!(FACTOR, 0, "FACTOR must be greater than 0")
     }
 
     #[inline]
-    fn capacity(segments: usize) -> usize {
+    fn capacity(&self, segments: usize) -> usize {
         segments * (segments + 1) / 2 * FACTOR
     }
 
     #[inline]
-    fn segment_size(segment: usize) -> usize {
+    fn segment_size(&self, segment: usize) -> usize {
         (segment + 1) * FACTOR
     }
 
     #[inline]
-    fn segment_and_offset(index: usize) -> (usize, usize) {
+    fn segment_and_offset(&self, index: usize) -> (usize, usize) {
         let linear_segment = index / FACTOR;
         let segment = ((8 * linear_segment + 1).sqrt() - 1) / 2;
 
-        (segment, index - Self::capacity(segment))
+        (segment, index - self.capacity(segment))
     }
 }
 
 /// Exponential growth, each subsequent segment is as big as the sum of all segments before.
 pub struct Exponential<const FACTOR: usize = 16>;
 impl<const FACTOR: usize> MemConfig for Exponential<FACTOR> {
+    fn new() -> Self {
+        Self {}
+    }
+
     #[track_caller]
     fn debug_assert_config() {
         debug_assert_ne!(FACTOR, 0, "FACTOR must be greater than 0")
     }
 
     #[inline]
-    fn capacity(segments: usize) -> usize {
+    fn capacity(&self, segments: usize) -> usize {
         if segments == 0 {
             0
         } else {
@@ -98,7 +112,7 @@ impl<const FACTOR: usize> MemConfig for Exponential<FACTOR> {
     }
 
     #[inline]
-    fn segment_size(segment: usize) -> usize {
+    fn segment_size(&self, segment: usize) -> usize {
         if segment == 0 {
             FACTOR
         } else {
@@ -107,7 +121,7 @@ impl<const FACTOR: usize> MemConfig for Exponential<FACTOR> {
     }
 
     #[inline]
-    fn segment_and_offset(index: usize) -> (usize, usize) {
+    fn segment_and_offset(&self, index: usize) -> (usize, usize) {
         let linear_segment = index / FACTOR;
 
         if linear_segment == 0 {
@@ -124,7 +138,7 @@ pub fn linear_capacity() {
     let capacities: &[usize] = &[0, 32, 64, 96, 128, 160, 192, 224];
 
     for i in 0..capacities.len() {
-        assert_eq!(Linear::<32>::capacity(i), capacities[i])
+        assert_eq!(Linear::<32>::new().capacity(i), capacities[i])
     }
 }
 
@@ -133,13 +147,13 @@ pub fn linear_segment_size() {
     let segment_sizes: &[usize] = &[1, 1, 1, 1, 1, 1, 1];
 
     for i in 0..segment_sizes.len() {
-        assert_eq!(Linear::<1>::segment_size(i), segment_sizes[i])
+        assert_eq!(Linear::<1>::new().segment_size(i), segment_sizes[i])
     }
 
     let segment_sizes: &[usize] = &[3, 3, 3, 3, 3, 3, 3];
 
     for i in 0..segment_sizes.len() {
-        assert_eq!(Linear::<3>::segment_size(i), segment_sizes[i])
+        assert_eq!(Linear::<3>::new().segment_size(i), segment_sizes[i])
     }
 }
 
@@ -157,7 +171,7 @@ pub fn linear_segment_and_offset() {
     ];
 
     for i in 1..segment_indices.len() {
-        assert_eq!(Linear::<2>::segment_and_offset(i), segment_indices[i])
+        assert_eq!(Linear::<2>::new().segment_and_offset(i), segment_indices[i])
     }
 }
 
@@ -167,14 +181,14 @@ pub fn proportional_capacity() {
     let capacities: &[usize] = &[0, 1, 3, 6, 10, 15, 21];
 
     for i in 0..capacities.len() {
-        assert_eq!(Proportional::<1>::capacity(i), capacities[i])
+        assert_eq!(Proportional::<1>::new().capacity(i), capacities[i])
     }
 
     // For FACTOR=3
     let capacities: &[usize] = &[0, 3, 9, 18, 30, 45];
 
     for i in 0..capacities.len() {
-        assert_eq!(Proportional::<3>::capacity(i), capacities[i])
+        assert_eq!(Proportional::<3>::new().capacity(i), capacities[i])
     }
 }
 
@@ -183,19 +197,19 @@ pub fn proportional_segment_size() {
     let segment_sizes: &[usize] = &[1, 2, 3, 4, 5, 6, 7, 8];
 
     for i in 0..segment_sizes.len() {
-        assert_eq!(Proportional::<1>::segment_size(i), segment_sizes[i])
+        assert_eq!(Proportional::<1>::new().segment_size(i), segment_sizes[i])
     }
 
     let segment_sizes: &[usize] = &[2, 4, 6, 8, 10, 12, 14, 16];
 
     for i in 0..segment_sizes.len() {
-        assert_eq!(Proportional::<2>::segment_size(i), segment_sizes[i])
+        assert_eq!(Proportional::<2>::new().segment_size(i), segment_sizes[i])
     }
 
     let segment_sizes: &[usize] = &[3, 6, 9, 12, 15, 18, 21, 24];
 
     for i in 0..segment_sizes.len() {
-        assert_eq!(Proportional::<3>::segment_size(i), segment_sizes[i])
+        assert_eq!(Proportional::<3>::new().segment_size(i), segment_sizes[i])
     }
 }
 
@@ -216,7 +230,10 @@ pub fn proportional_segment_and_offset() {
     ];
 
     for i in 1..segment_indices.len() {
-        assert_eq!(Proportional::<1>::segment_and_offset(i), segment_indices[i])
+        assert_eq!(
+            Proportional::<1>::new().segment_and_offset(i),
+            segment_indices[i]
+        )
     }
 
     let segment_indices: &[(usize, usize)] = &[
@@ -237,7 +254,10 @@ pub fn proportional_segment_and_offset() {
     ];
 
     for i in 1..segment_indices.len() {
-        assert_eq!(Proportional::<2>::segment_and_offset(i), segment_indices[i])
+        assert_eq!(
+            Proportional::<2>::new().segment_and_offset(i),
+            segment_indices[i]
+        )
     }
 }
 
@@ -246,7 +266,7 @@ pub fn exponential_capacity() {
     let capacities: &[usize] = &[0, 1, 2, 4, 8, 16, 32, 64];
 
     for i in 0..capacities.len() {
-        assert_eq!(Exponential::<1>::capacity(i), capacities[i])
+        assert_eq!(Exponential::<1>::new().capacity(i), capacities[i])
     }
 }
 
@@ -255,13 +275,13 @@ pub fn exponential_segment_size() {
     let segment_sizes: &[usize] = &[1, 1, 2, 4, 8, 16, 32, 64];
 
     for i in 0..segment_sizes.len() {
-        assert_eq!(Exponential::<1>::segment_size(i), segment_sizes[i])
+        assert_eq!(Exponential::<1>::new().segment_size(i), segment_sizes[i])
     }
 
     let segment_sizes: &[usize] = &[4, 4, 8, 16, 32, 64, 128, 256];
 
     for i in 0..segment_sizes.len() {
-        assert_eq!(Exponential::<4>::segment_size(i), segment_sizes[i])
+        assert_eq!(Exponential::<4>::new().segment_size(i), segment_sizes[i])
     }
 }
 
@@ -272,7 +292,10 @@ pub fn exponential_segment_and_offset() {
         &[(0, 0), (1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2)];
 
     for i in 1..segment_indices.len() {
-        assert_eq!(Exponential::<1>::segment_and_offset(i), segment_indices[i])
+        assert_eq!(
+            Exponential::<1>::new().segment_and_offset(i),
+            segment_indices[i]
+        )
     }
 
     // FACTOR = 2
@@ -297,7 +320,10 @@ pub fn exponential_segment_and_offset() {
     ];
 
     for i in 1..segment_indices.len() {
-        assert_eq!(Exponential::<2>::segment_and_offset(i), segment_indices[i])
+        assert_eq!(
+            Exponential::<2>::new().segment_and_offset(i),
+            segment_indices[i]
+        )
     }
 }
 
@@ -311,18 +337,18 @@ pub fn linear() {
     // segments
     let mut sum = 0_usize;
     for i in 0..10000000000 {
-        sum += DuT::segment_size(i);
-        assert_eq!(DuT::capacity(i + 1), sum)
+        sum += DuT::new().segment_size(i);
+        assert_eq!(DuT::new().capacity(i + 1), sum)
     }
 
     // indices
     for i in 1..10000000000 {
-        let (segment, index) = DuT::segment_and_offset(i);
-        assert!(index < DuT::segment_size(segment));
+        let (segment, index) = DuT::new().segment_and_offset(i);
+        assert!(index < DuT::new().segment_size(segment));
         if index == 0 {
-            let (psegment, pindex) = DuT::segment_and_offset(i - 1);
+            let (psegment, pindex) = DuT::new().segment_and_offset(i - 1);
             assert_eq!(psegment, segment - 1);
-            assert!(pindex < DuT::segment_size(psegment));
+            assert!(pindex < DuT::new().segment_size(psegment));
         }
     }
 }
@@ -335,18 +361,18 @@ pub fn proportional() {
     // segments
     let mut sum = 0_usize;
     for i in 0..1000000000 {
-        sum += DuT::segment_size(i);
-        assert_eq!(DuT::capacity(i + 1), sum)
+        sum += DuT::new().segment_size(i);
+        assert_eq!(DuT::new().capacity(i + 1), sum)
     }
 
     // indices
     for i in 1..10000000000 {
-        let (segment, index) = DuT::segment_and_offset(i);
-        assert!(index < DuT::segment_size(segment));
+        let (segment, index) = DuT::new().segment_and_offset(i);
+        assert!(index < DuT::new().segment_size(segment));
         if index == 0 {
-            let (psegment, pindex) = DuT::segment_and_offset(i - 1);
+            let (psegment, pindex) = DuT::new().segment_and_offset(i - 1);
             assert_eq!(psegment, segment - 1);
-            assert!(pindex < DuT::segment_size(psegment));
+            assert!(pindex < DuT::new().segment_size(psegment));
         }
     }
 }
@@ -359,18 +385,18 @@ pub fn exponential() {
     // segments
     let mut sum = 0_usize;
     for i in 0..60 {
-        sum += DuT::segment_size(i);
-        assert_eq!(DuT::capacity(i + 1), sum)
+        sum += DuT::new().segment_size(i);
+        assert_eq!(DuT::new().capacity(i + 1), sum)
     }
 
     // indices
     for i in 1..10000000000 {
-        let (segment, index) = DuT::segment_and_offset(i);
-        assert!(index < DuT::segment_size(segment));
+        let (segment, index) = DuT::new().segment_and_offset(i);
+        assert!(index < DuT::new().segment_size(segment));
         if index == 0 {
-            let (psegment, pindex) = DuT::segment_and_offset(i - 1);
+            let (psegment, pindex) = DuT::new().segment_and_offset(i - 1);
             assert_eq!(psegment, segment - 1);
-            assert!(pindex < DuT::segment_size(psegment));
+            assert!(pindex < DuT::new().segment_size(psegment));
         }
     }
 }


### PR DESCRIPTION
This is on top of my last PR. 

Making MemConfig stateful instead wrapping it in PhantomData could potentially have some advantages.

That saied I implemented that for Exponential, caching 'capacity' there and removed the 'capacity' field from from SegVec.

Unfortunally I see a slight performance regression, still i believe its worth integrating this. The performance regression shouldn't be a big problem in real use. Eventually it may become better optimized.

Nothing been done for Proportional, that probably needs to cache the capacity as well.
