### PR TITLE
Subslicing and SegVec::from(Slice)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ harness = false
 [[bench]]
 name = "segvec_benchmark2"
 harness = false
+
+[[bench]]
+name = "slice_and_iter"
+harness = false

--- a/benches/slice_and_iter.rs
+++ b/benches/slice_and_iter.rs
@@ -14,6 +14,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("slice");
 
+    let mut v: Vec<usize> = Vec::new();
+    let mut r = 0xf00ba;
+    for _ in 0..10000 {
+        v.push(fast_prng(&mut r) as usize);
+    }
+
+    group.bench_function("full Vec iteration", |b| {
+        b.iter(|| {
+            let mut iterator = v.iter();
+            while black_box(iterator.next().is_some()) {}
+        });
+    });
+
     let mut v: SegVec<usize> = SegVec::new();
     let mut r = 0xf00ba;
     for _ in 0..10000 {

--- a/benches/slice_and_iter.rs
+++ b/benches/slice_and_iter.rs
@@ -20,6 +20,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         v.push(fast_prng(&mut r) as usize);
     }
 
+    group.bench_function("full segvec iteration", |b| {
+        b.iter(|| {
+            let mut iterator = v.iter();
+            while black_box(iterator.next().is_some()) {}
+        });
+    });
+
+    group.bench_function("full slice iteration", |b| {
+        b.iter(|| {
+            let mut iterator = v.slice(..).iter();
+            while black_box(iterator.next().is_some()) {}
+        });
+    });
+
     let slice = v.slice(100..9000);
     let l = slice.len();
 

--- a/benches/slice_and_iter.rs
+++ b/benches/slice_and_iter.rs
@@ -14,26 +14,25 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("slice");
 
-    let mut v: Vec<usize> = Vec::new();
-    let mut r = 0xf00ba;
-    for _ in 0..10000 {
-        v.push(fast_prng(&mut r) as usize);
-    }
-
     group.bench_function("full Vec iteration", |b| {
+        let mut v: Vec<usize> = Vec::new();
+        let mut r = 0xf00ba;
+        for _ in 0..10000 {
+            v.push(fast_prng(&mut r) as usize);
+        }
         b.iter(|| {
             let mut iterator = v.iter();
             while black_box(iterator.next().is_some()) {}
         });
     });
 
-    let mut v: SegVec<usize> = SegVec::new();
-    let mut r = 0xf00ba;
-    for _ in 0..10000 {
-        v.push(fast_prng(&mut r) as usize);
-    }
-
     group.bench_function("full segvec iteration", |b| {
+        let mut v: SegVec<usize> = SegVec::new();
+        let mut r = 0xf00ba;
+        for _ in 0..10000 {
+            v.push(fast_prng(&mut r) as usize);
+        }
+
         b.iter(|| {
             let mut iterator = v.iter();
             while black_box(iterator.next().is_some()) {}
@@ -41,16 +40,26 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     group.bench_function("full slice iteration", |b| {
+        let mut v: SegVec<usize> = SegVec::new();
+        let mut r = 0xf00ba;
+        for _ in 0..10000 {
+            v.push(fast_prng(&mut r) as usize);
+        }
+
         b.iter(|| {
             let mut iterator = v.slice(..).iter();
             while black_box(iterator.next().is_some()) {}
         });
     });
 
-    let slice = v.slice(100..9000);
-    let l = slice.len();
-
     group.bench_function("slice iteration", |b| {
+        let mut v: SegVec<usize> = SegVec::new();
+        let mut r = 0xf00ba;
+        for _ in 0..10000 {
+            v.push(fast_prng(&mut r) as usize);
+        }
+
+        let slice = v.slice(100..9000);
         b.iter(|| {
             let mut iterator = slice.iter();
             while black_box(iterator.next().is_some()) {}
@@ -58,6 +67,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     group.bench_function("slice indexing", |b| {
+        let mut v: SegVec<usize> = SegVec::new();
+        let mut r = 0xf00ba;
+        for _ in 0..10000 {
+            v.push(fast_prng(&mut r) as usize);
+        }
         let mut r = 0xbaf00;
 
         b.iter(|| {

--- a/benches/slice_and_iter.rs
+++ b/benches/slice_and_iter.rs
@@ -1,0 +1,45 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use segvec::*;
+
+#[inline(always)]
+fn fast_prng(state: &mut u32) -> usize {
+    let rand = *state;
+    *state = rand << 1 ^ ((rand >> 30) & 1) ^ ((rand >> 2) & 1);
+    rand as usize
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    //const N: i32 = 10000;
+    const N: usize = 10000;
+
+    let mut group = c.benchmark_group("slice");
+
+    let mut v: SegVec<usize> = SegVec::new();
+    let mut r = 0xf00ba;
+    for _ in 0..10000 {
+        v.push(fast_prng(&mut r) as usize);
+    }
+
+    let slice = v.slice(100..9000);
+    let l = slice.len();
+
+    group.bench_function("slice iteration", |b| {
+        b.iter(|| {
+            let mut iterator = slice.iter();
+            while black_box(iterator.next().is_some()) {}
+        });
+    });
+
+    group.bench_function("slice indexing", |b| {
+        let mut r = 0xbaf00;
+
+        b.iter(|| {
+            for _ in 0..N {
+                _ = black_box(v.get(fast_prng(&mut r) as usize % l));
+            }
+        });
+    });
+}
+
+criterion_group!(slice_and_iter_bench, criterion_benchmark);
+criterion_main!(slice_and_iter_bench);

--- a/benches/slice_and_iter.rs
+++ b/benches/slice_and_iter.rs
@@ -62,7 +62,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             for _ in 0..N {
-                _ = black_box(v.get(fast_prng(&mut r) as usize % l));
+                _ = black_box(v.get(fast_prng(&mut r) as usize % 8900));
             }
         });
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1128,6 +1128,7 @@ pub struct SliceIter<'a, T: 'a> {
 impl<'a, T: 'a> Iterator for SliceIter<'a, T> {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.index += 1;
         self.iter.next()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,6 @@ pub mod detail {
 }
 
 use std::cmp;
-// TODO: unused yet use std::convert::TryFrom;
-use std::convert::From;
 use std::default::Default;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -853,20 +851,6 @@ impl<T, C: MemConfig> IntoIterator for SegVec<T, C> {
             size: self.len,
             iter: self.segments.into_iter().flatten(),
         }
-    }
-}
-
-/// Creates an new [`SegVec`][crate::SegVec] from a [`Slice`][crate::Slice].
-impl<T: Clone, C: MemConfig> From<Slice<'_, T>> for SegVec<T, C> {
-    fn from(slice: Slice<'_, T>) -> Self {
-        slice.iter().cloned().collect()
-    }
-}
-
-/// Creates an new [`SegVec`][crate::SegVec] from a reference to [`Slice`][crate::Slice].
-impl<T: Clone, C: MemConfig> From<&Slice<'_, T>> for SegVec<T, C> {
-    fn from(slice: &Slice<'_, T>) -> Self {
-        slice.iter().cloned().collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod detail {
 
 use std::cmp;
 // TODO: unused yet use std::convert::TryFrom;
+use std::convert::From;
 use std::default::Default;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -852,6 +853,20 @@ impl<T, C: MemConfig> IntoIterator for SegVec<T, C> {
             size: self.len,
             iter: self.segments.into_iter().flatten(),
         }
+    }
+}
+
+/// Creates an new [`SegVec`][crate::SegVec] from a [`Slice`][crate::Slice].
+impl<T: Clone, C: MemConfig> From<Slice<'_, T>> for SegVec<T, C> {
+    fn from(slice: Slice<'_, T>) -> Self {
+        slice.iter().cloned().collect()
+    }
+}
+
+/// Creates an new [`SegVec`][crate::SegVec] from a reference to [`Slice`][crate::Slice].
+impl<T: Clone, C: MemConfig> From<&Slice<'_, T>> for SegVec<T, C> {
+    fn from(slice: &Slice<'_, T>) -> Self {
+        slice.iter().cloned().collect()
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -363,6 +363,7 @@ fn test_slice() {
     let s3 = v.slice(2..6);
     let s4 = v.slice(..);
     let s5 = v.slice(..0);
+    let s6 = v.slice(1..1);
     // invalid:
     // v.truncate(0); // <- Slices immutably borrow the underlying SegVec
     assert_eq!(s1.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3, 4]);
@@ -373,6 +374,7 @@ fn test_slice() {
         vec![1, 2, 3, 4, 5, 6, 7, 8]
     );
     assert_eq!(s5.iter().copied().collect::<Vec<i32>>(), vec![]);
+    assert_eq!(s6.iter().copied().collect::<Vec<i32>>(), vec![]);
 }
 
 #[test]
@@ -398,6 +400,49 @@ fn test_slice_mut() {
 }
 
 #[test]
+fn test_slice_iter() {
+    let mut v = SegVec::<i32, Exponential<1>>::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+    assert_eq!(v.len(), 7);
+    assert_eq!(v.capacity(), 8);
+
+    let s = v.slice(..);
+
+    assert_eq!(s.iter().size_hint(), (7, Some(7)));
+    assert_eq!(
+        s.iter().copied().collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5, 6, 7]
+    );
+    // PLANNED: DoubleEndedIterator for SliceIter
+    // assert_eq!(
+    //     s.iter().rev().copied().collect::<Vec<_>>(),
+    //     vec![7, 6, 5, 4, 3, 2, 1]
+    // );
+
+    let mut iter = s.iter();
+    assert_eq!(iter.next().unwrap(), &1);
+    // PLANNED: assert_eq!(iter.next_back().unwrap(), &7);
+    assert_eq!(iter.size_hint(), (6, Some(6)));
+    assert_eq!(iter.next().unwrap(), &2);
+    // PLANNED: assert_eq!(iter.next_back().unwrap(), &6);
+    assert_eq!(iter.size_hint(), (5, Some(5)));
+    assert_eq!(iter.next().unwrap(), &3);
+    // PLANNED: assert_eq!(iter.next_back().unwrap(), &5);
+    assert_eq!(iter.size_hint(), (4, Some(4)));
+    // PLANNED: assert_eq!(iter.next_back().unwrap(), &4);
+    //assert_eq!(iter.size_hint(), (0, Some(0)));
+
+    assert_eq!(s.len(), 7);
+    // PLANNED: assert_eq!(v.capacity(), 8);
+}
+
+#[test]
 fn test_segmented_iter() {
     let mut v = SegVec::<i32, Exponential<1>>::new();
     v.push(1);
@@ -410,17 +455,15 @@ fn test_segmented_iter() {
     assert_eq!(v.len(), 7);
     assert_eq!(v.capacity(), 8);
 
-    //TODO: assert_eq!(v.iter().size_hint(), (7, Some(7)));
-
     let mut iter = v.slice(..).segmented_iter();
+    assert_eq!(iter.size_hint(), (4, Some(4)));
     assert_eq!(iter.next().unwrap(), &[1]);
-    //TODO: assert_eq!(iter.size_hint(), (5, Some(5)));
+    assert_eq!(iter.size_hint(), (3, Some(3)));
     assert_eq!(iter.next().unwrap(), &[2]);
-    //TODO: assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.size_hint(), (2, Some(2)));
     assert_eq!(iter.next().unwrap(), &[3, 4]);
     assert_eq!(iter.next().unwrap(), &[5, 6, 7]);
-    //TODO: assert_eq!(iter.size_hint(), (1, Some(1)));
-    //TODO: assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.size_hint(), (0, Some(0)));
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -378,6 +378,51 @@ fn test_slice() {
 }
 
 #[test]
+fn test_subslice() {
+    let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+    v.push(8);
+    let slice = v.slice(..);
+    assert_eq!(
+        slice.iter().copied().collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5, 6, 7, 8]
+    );
+
+    let subslice = slice.slice(2..5);
+    assert_eq!(subslice.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+
+    let subslice = slice.slice(..5);
+    assert_eq!(
+        subslice.iter().copied().collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5]
+    );
+
+    let subslice = slice.slice(2..);
+    assert_eq!(
+        subslice.iter().copied().collect::<Vec<_>>(),
+        vec![3, 4, 5, 6, 7, 8]
+    );
+
+    let subslice = slice.slice(2..=5);
+    assert_eq!(
+        subslice.iter().copied().collect::<Vec<_>>(),
+        vec![3, 4, 5, 6]
+    );
+
+    let subslice = slice.slice(..);
+    assert_eq!(
+        subslice.iter().copied().collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5, 6, 7, 8]
+    );
+}
+
+#[test]
 fn test_slice_mut() {
     let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
     v.push(1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -398,6 +398,32 @@ fn test_slice_mut() {
 }
 
 #[test]
+fn test_segmented_iter() {
+    let mut v = SegVec::<i32, Exponential<1>>::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+    assert_eq!(v.len(), 7);
+    assert_eq!(v.capacity(), 8);
+
+    //TODO: assert_eq!(v.iter().size_hint(), (7, Some(7)));
+
+    let mut iter = v.slice(..).segmented_iter();
+    assert_eq!(iter.next().unwrap(), &[1]);
+    //TODO: assert_eq!(iter.size_hint(), (5, Some(5)));
+    assert_eq!(iter.next().unwrap(), &[2]);
+    //TODO: assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.next().unwrap(), &[3, 4]);
+    assert_eq!(iter.next().unwrap(), &[5, 6, 7]);
+    //TODO: assert_eq!(iter.size_hint(), (1, Some(1)));
+    //TODO: assert_eq!(iter.size_hint(), (0, Some(0)));
+}
+
+#[test]
 fn test_sort() {
     let mut rng = rand::thread_rng();
     for i in 0..1000usize {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -423,6 +423,34 @@ fn test_subslice() {
 }
 
 #[test]
+fn from_slice() {
+    let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+    v.push(8);
+    let slice = v.slice(..);
+    assert_eq!(
+        slice.iter().copied().collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5, 6, 7, 8]
+    );
+
+    let subslice = slice.slice(2..5);
+    assert_eq!(subslice.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+
+    let v2 = SegVec::<_, Exponential<1>>::from(&subslice);
+    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+
+    // can be used to change the MemConfig as well
+    let v2 = SegVec::<_, Linear<4>>::from(subslice);
+    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+}
+
+#[test]
 fn test_slice_mut() {
     let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
     v.push(1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -422,33 +422,34 @@ fn test_subslice() {
     );
 }
 
-#[test]
-fn from_slice() {
-    let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
-    v.push(1);
-    v.push(2);
-    v.push(3);
-    v.push(4);
-    v.push(5);
-    v.push(6);
-    v.push(7);
-    v.push(8);
-    let slice = v.slice(..);
-    assert_eq!(
-        slice.iter().copied().collect::<Vec<_>>(),
-        vec![1, 2, 3, 4, 5, 6, 7, 8]
-    );
-
-    let subslice = slice.slice(2..5);
-    assert_eq!(subslice.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
-
-    let v2 = SegVec::<_, Exponential<1>>::from(&subslice);
-    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
-
-    // can be used to change the MemConfig as well
-    let v2 = SegVec::<_, Linear<4>>::from(subslice);
-    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
-}
+// PLANNED: use from_iter as in https://github.com/mccolljr/segvec/pull/26#issuecomment-1614107293
+// #[test]
+// fn from_slice() {
+//     let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
+//     v.push(1);
+//     v.push(2);
+//     v.push(3);
+//     v.push(4);
+//     v.push(5);
+//     v.push(6);
+//     v.push(7);
+//     v.push(8);
+//     let slice = v.slice(..);
+//     assert_eq!(
+//         slice.iter().copied().collect::<Vec<_>>(),
+//         vec![1, 2, 3, 4, 5, 6, 7, 8]
+//     );
+// 
+//     let subslice = slice.slice(2..5);
+//     assert_eq!(subslice.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+// 
+//     let v2 = SegVec::<_, Exponential<1>>::from(&subslice);
+//     assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+// 
+//     // can be used to change the MemConfig as well
+//     let v2 = SegVec::<_, Linear<4>>::from(subslice);
+//     assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+// }
 
 #[test]
 fn test_slice_mut() {


### PR DESCRIPTION
With this one can create new (Sub-) Slices from existing Slices and turn them into owned SegVecs by SegVec::from(someslice) and SegVec::from(&someslice).

as this was made on top of 'index_improvement' so you can merge only this to include both PR's or I rebase later.

This finalizes my immediate needs. After merging I'll do some clippy/cleanup PR which then may make this suitable for a new release. The other things I noted/planned will be added later.