### PR TITLE
Iterator/Slice improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 smallvec = { version = "1.10.0", features = ["const_generics", "union"], optional = true }
 thin-vec = { version = "0.2.3", optional = true }
 num-integer = "0.1.45"
+either = "1.8.1"
 
 [features]
 small-vec = ["smallvec"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -854,20 +854,6 @@ impl<T, C: MemConfig> IntoIterator for SegVec<T, C> {
     }
 }
 
-/// Creates an new [`SegVec`][crate::SegVec] from a [`Slice`][crate::Slice].
-impl<T: Clone, C: MemConfig> From<Slice<'_, T>> for SegVec<T, C> {
-    fn from(slice: Slice<'_, T>) -> Self {
-        slice.iter().cloned().collect()
-    }
-}
-
-/// Creates an new [`SegVec`][crate::SegVec] from a reference to [`Slice`][crate::Slice].
-impl<T: Clone, C: MemConfig> From<&Slice<'_, T>> for SegVec<T, C> {
-    fn from(slice: &Slice<'_, T>) -> Self {
-        slice.iter().cloned().collect()
-    }
-}
-
 /// Iterator over immutable references to items in a [`SegVec`][crate::SegVec].
 pub struct Iter<'a, T> {
     size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -991,17 +991,6 @@ fn checked_log2_floor(v: usize) -> Option<u32> {
     }
 }
 
-fn slice_index_to_base_index(
-    start_idx: usize,
-    slice_idx: usize,
-    slice_len: usize,
-) -> Option<usize> {
-    match start_idx.checked_add(slice_idx) {
-        Some(idx) if idx - start_idx < slice_len => Some(idx),
-        _ => None,
-    }
-}
-
 #[cold]
 fn capacity_overflow() -> ! {
     panic!("SegVec: capacity overflow")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1155,7 +1155,7 @@ impl<'a, T: 'a> Iterator for SegmentedIter<'a, T> {
     type Item = &'a [T];
 
     fn next(&mut self) -> Option<Self::Item> {
-        // We never return a empty slice
+        // We never return an empty slice
         if self.slice.len == 0 || self.start.0 > self.end.0 {
             return None;
         }
@@ -1180,7 +1180,7 @@ impl<'a, T: 'a> ExactSizeIterator for SegmentedIter<'a, T> {}
 
 impl<'a, T> DoubleEndedIterator for SegmentedIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        // We never return a empty slice
+        // We never return an empty slice
         if self.slice.len == 0 || self.start.0 > self.end.0 {
             return None;
         }
@@ -1190,13 +1190,15 @@ impl<'a, T> DoubleEndedIterator for SegmentedIter<'a, T> {
         } else {
             &self.slice.inner.segment(self.end.0)[..=self.end.1]
         };
+        // need to be careful not to underflow self.end.0 when done.
         if self.end.0 != 0 {
             self.end = (
                 self.end.0 - 1,
                 self.slice.inner.segment(self.end.0 - 1).len() - 1,
             );
         } else {
-            self.start = (self.start.0 + 1, 0);
+            // with start.0 > end.0 the iterator is flagged as 'done'
+            self.start = (1, 0);
         }
         Some(ret)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -980,30 +980,6 @@ impl<'a, T, C: MemConfig> Drop for Drain<'a, T, C> {
     }
 }
 
-// Extends Index<> with methods to get segments and (segment,offset) tuples
-trait SegmentIndex<T>: Index<usize, Output = T> {
-    fn index(&self, i: usize) -> &T;
-    fn segment_and_offset(&self, i: usize) -> (usize, usize);
-    fn segment(&self, i: usize) -> &[T];
-}
-
-impl<T, C: MemConfig> SegmentIndex<T> for SegVec<T, C> {
-    #[inline]
-    fn index(&self, i: usize) -> &T {
-        Index::index(self, i)
-    }
-
-    #[inline]
-    fn segment_and_offset(&self, i: usize) -> (usize, usize) {
-        self.config.segment_and_offset(i)
-    }
-
-    #[inline]
-    fn segment(&self, i: usize) -> &[T] {
-        &self.segments[i]
-    }
-}
-
 /// Returns the highest power of 2 that is less than or equal to `v` when `v` is non-zero.
 /// If `v` is zero, `None` is returned.
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -854,6 +854,20 @@ impl<T, C: MemConfig> IntoIterator for SegVec<T, C> {
     }
 }
 
+/// Creates an new [`SegVec`][crate::SegVec] from a [`Slice`][crate::Slice].
+impl<T: Clone, C: MemConfig> From<Slice<'_, T>> for SegVec<T, C> {
+    fn from(slice: Slice<'_, T>) -> Self {
+        slice.iter().cloned().collect()
+    }
+}
+
+/// Creates an new [`SegVec`][crate::SegVec] from a reference to [`Slice`][crate::Slice].
+impl<T: Clone, C: MemConfig> From<&Slice<'_, T>> for SegVec<T, C> {
+    fn from(slice: &Slice<'_, T>) -> Self {
+        slice.iter().cloned().collect()
+    }
+}
+
 /// Iterator over immutable references to items in a [`SegVec`][crate::SegVec].
 pub struct Iter<'a, T> {
     size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ mod tests;
 mod mem_config;
 pub use mem_config::*;
 
+mod slice;
+pub use slice::*;
+
 pub mod detail {
     #[cfg(feature = "thin-segments")]
     pub type Segment<T> = thin_vec::ThinVec<T>;
@@ -600,11 +603,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
         R: RangeBounds<usize>,
     {
         let (start, end) = bounds(self.len, "SegVec::slice", range);
-        Slice {
-            inner: self,
-            start,
-            len: end - start,
-        }
+        Slice::new(self, start, end - start)
     }
 
     /// Returns a [`SliceMut`][crate::SliceMut] over the given range in the
@@ -628,11 +627,7 @@ impl<T, C: MemConfig> SegVec<T, C> {
         R: RangeBounds<usize>,
     {
         let (start, end) = bounds(self.len, "SegVec::slice_mut", range);
-        SliceMut {
-            inner: self,
-            start,
-            len: end - start,
-        }
+        SliceMut::new(self, start, end - start)
     }
 
     /// Reverses the elements in the [`SegVec`][crate::SegVec].
@@ -1008,280 +1003,6 @@ impl<T, C: MemConfig> SegmentIndex<T> for SegVec<T, C> {
         &self.segments[i]
     }
 }
-
-/// Provides an immutable view of elements from a range in [`SegVec`][crate::SegVec].
-pub struct Slice<'a, T: 'a> {
-    inner: &'a (dyn SegmentIndex<T>),
-    start: usize,
-    len: usize,
-}
-
-impl<'a, T: 'a> Copy for Slice<'a, T> {}
-
-impl<'a, T: 'a> Clone for Slice<'a, T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<'a, T: Debug + 'a> Debug for Slice<'a, T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_list().entries(self.iter()).finish()
-    }
-}
-
-impl<'a, T: 'a> Slice<'a, T> {
-    /// Returns the number of elements in the [`Slice`][crate::Slice].
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    /// Returns an iterator over immutable references to the elements of the
-    /// [`Slice`][crate::Slice].
-    pub fn iter(&self) -> SliceIter<'a, T> {
-        SliceIter {
-            iter: self.segmented_iter().flatten(),
-            start: 0,
-            end: self.len,
-        }
-    }
-
-    /// Returns an iterator over immutable references of slices of elements of the
-    /// [`Slice`][crate::Slice].
-    pub fn segmented_iter(&self) -> SegmentedIter<'a, T> {
-        let start = self.inner.segment_and_offset(self.start);
-        // The 'end' is inclusive because we don't want to spill into the next segment. For an
-        // empty slice we have to prevent integer underflow, we just store a (0,0), this will
-        // not be used later since len is checked first to be not zero.
-        let end = if self.len > 0 {
-            self.inner.segment_and_offset(self.start + self.len - 1)
-        } else {
-            (0, 0)
-        };
-
-        SegmentedIter {
-            slice: *self,
-            start,
-            end,
-        }
-    }
-
-    /// Sub-slices an existing slice, returns a new [`Slice`][crate::Slice] covering the given
-    /// `range`.
-    ///
-    /// # Panics
-    /// - If the end index is greater than `self.len()`
-    /// - If the start index is greater than the end index.
-    pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> Self {
-        let (start, end) = bounds(self.len, "Slice::subslice", range);
-        Slice {
-            inner: self.inner,
-            start: self.start + start,
-            len: end - start,
-        }
-    }
-}
-
-impl<'a, T: 'a> Index<usize> for Slice<'a, T> {
-    type Output = T;
-
-    fn index(&self, index: usize) -> &'a Self::Output {
-        match slice_index_to_base_index(self.start, index, self.len) {
-            Some(idx) => SegmentIndex::index(self.inner, idx),
-            _ => index_oob("Slice::index", index, self.len),
-        }
-    }
-}
-
-impl<'a, T: 'a> IntoIterator for Slice<'a, T> {
-    type IntoIter = SliceIter<'a, T>;
-    type Item = &'a T;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-/// Iterator over immutable references to the elements of a [`Slice`][crate::Slice].
-pub struct SliceIter<'a, T: 'a> {
-    iter: Flatten<SegmentedIter<'a, T>>,
-    // Since Flatten is opaque we have to do our own accounting for size_hint here.
-    start: usize,
-    end: usize,
-}
-
-impl<'a, T: 'a> Iterator for SliceIter<'a, T> {
-    type Item = &'a T;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.end > self.start {
-            self.start += 1;
-            self.iter.next()
-        } else {
-            None
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let left = self.end - self.start;
-        (left, Some(left))
-    }
-}
-
-impl<'a, T: 'a> FusedIterator for SliceIter<'a, T> {}
-impl<'a, T: 'a> ExactSizeIterator for SliceIter<'a, T> {}
-
-impl<'a, T> DoubleEndedIterator for SliceIter<'a, T> {
-    #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.end > self.start {
-            self.end -= 1;
-            self.iter.next_back()
-        } else {
-            None
-        }
-    }
-}
-
-/// Iterator over immutable references to slices of the elements of a [`Slice`][crate::Slice].
-pub struct SegmentedIter<'a, T: 'a> {
-    slice: Slice<'a, T>,
-    start: (usize, usize),
-    end: (usize, usize),
-}
-
-impl<'a, T: 'a> Iterator for SegmentedIter<'a, T> {
-    type Item = &'a [T];
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // We never return an empty slice
-        if self.slice.len == 0 || self.start.0 > self.end.0 {
-            return None;
-        }
-
-        let ret = if self.start.0 == self.end.0 {
-            &self.slice.inner.segment(self.start.0)[self.start.1..=self.end.1]
-        } else {
-            &self.slice.inner.segment(self.start.0)[self.start.1..]
-        };
-        self.start = (self.start.0 + 1, 0);
-        Some(ret)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let left = 1 + self.end.0 - self.start.0;
-        (left, Some(left))
-    }
-}
-
-impl<'a, T: 'a> FusedIterator for SegmentedIter<'a, T> {}
-impl<'a, T: 'a> ExactSizeIterator for SegmentedIter<'a, T> {}
-
-impl<'a, T> DoubleEndedIterator for SegmentedIter<'a, T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        // We never return an empty slice
-        if self.slice.len == 0 || self.start.0 > self.end.0 {
-            return None;
-        }
-
-        let ret = if self.start.0 == self.end.0 {
-            &self.slice.inner.segment(self.end.0)[self.start.1..=self.end.1]
-        } else {
-            &self.slice.inner.segment(self.end.0)[..=self.end.1]
-        };
-        // need to be careful not to underflow self.end.0 when done.
-        if self.end.0 != 0 {
-            self.end = (
-                self.end.0 - 1,
-                self.slice.inner.segment(self.end.0 - 1).len() - 1,
-            );
-        } else {
-            // with start.0 > end.0 the iterator is flagged as 'done'
-            self.start = (1, 0);
-        }
-        Some(ret)
-    }
-}
-
-/// Provides a mutable view of elements from a range in [`SegVec`][crate::SegVec].
-pub struct SliceMut<'a, T: 'a> {
-    inner: &'a mut dyn IndexMut<usize, Output = T>,
-    start: usize,
-    len: usize,
-}
-
-impl<'a, T: 'a> SliceMut<'a, T> {
-    /// Returns the number of elements in the [`SliceMut`][crate::SliceMut].
-    pub fn len(&self) -> usize {
-        self.len
-    }
-}
-
-impl<'a, T: 'a> Index<usize> for SliceMut<'a, T> {
-    type Output = T;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        match slice_index_to_base_index(self.start, index, self.len) {
-            Some(idx) => self.inner.index(idx),
-            _ => index_oob("SliceMut::index", index, self.len),
-        }
-    }
-}
-
-impl<'a, T: 'a> IndexMut<usize> for SliceMut<'a, T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        match slice_index_to_base_index(self.start, index, self.len) {
-            Some(idx) => self.inner.index_mut(idx),
-            _ => index_oob("SliceMut::index_mut", index, self.len),
-        }
-    }
-}
-
-impl<'a, T: 'a> IntoIterator for SliceMut<'a, T> {
-    type IntoIter = SliceMutIter<'a, T>;
-    type Item = &'a mut T;
-
-    fn into_iter(self) -> Self::IntoIter {
-        SliceMutIter {
-            slice: self,
-            index: 0,
-        }
-    }
-}
-
-/// Iterator over mutable references to the elements of a [`SliceMut`][crate::SliceMut].
-pub struct SliceMutIter<'a, T: 'a> {
-    slice: SliceMut<'a, T>,
-    index: usize,
-}
-
-impl<'a, T: 'a> Iterator for SliceMutIter<'a, T> {
-    type Item = &'a mut T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index < self.slice.len {
-            let index = self.index;
-            self.index += 1;
-            // SAFETY:
-            // 1. index corresponds to a valid value in the slice
-            // 2. the value at index must live for at least the lifetime 'a
-            // 3. from #1+2, it is known that a taking an &'a mut to the value in the
-            //    slice is safe
-            Some(unsafe { &mut *(self.slice.index_mut(index) as *mut T) })
-        } else {
-            None
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let left = self.slice.len - self.index;
-        (left, Some(left))
-    }
-}
-
-impl<'a, T: 'a> FusedIterator for SliceMutIter<'a, T> {}
-impl<'a, T: 'a> ExactSizeIterator for SliceMutIter<'a, T> {}
 
 /// Returns the highest power of 2 that is less than or equal to `v` when `v` is non-zero.
 /// If `v` is zero, `None` is returned.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,41 +1,5 @@
 use crate::*;
 
-/// Extends Index<> with methods to get segments and (segment,offset) tuples
-pub(crate) trait SegmentIndex<T>: Index<usize, Output = T> {
-    fn index(&self, i: usize) -> &T;
-    fn index_mut(&mut self, i: usize) -> &mut T;
-    fn segment_and_offset(&self, i: usize) -> (usize, usize);
-    fn segment(&self, i: usize) -> &[T];
-    fn segment_mut(&mut self, i: usize) -> &mut [T];
-}
-
-impl<T, C: MemConfig> SegmentIndex<T> for SegVec<T, C> {
-    #[inline]
-    fn index(&self, i: usize) -> &T {
-        Index::index(self, i)
-    }
-
-    #[inline]
-    fn index_mut(&mut self, i: usize) -> &mut T {
-        IndexMut::index_mut(self, i)
-    }
-
-    #[inline]
-    fn segment_and_offset(&self, i: usize) -> (usize, usize) {
-        self.config.segment_and_offset(i)
-    }
-
-    #[inline]
-    fn segment(&self, i: usize) -> &[T] {
-        &self.segments[i]
-    }
-
-    #[inline]
-    fn segment_mut(&mut self, i: usize) -> &mut [T] {
-        &mut self.segments[i]
-    }
-}
-
 /// Provides an immutable view of elements from a range in [`SegVec`][crate::SegVec].
 pub struct Slice<'a, T: 'a> {
     inner: &'a dyn SegmentIndex<T>,
@@ -341,6 +305,59 @@ impl<'a, T: 'a> Iterator for SliceMutIter<'a, T> {
 
 impl<'a, T: 'a> FusedIterator for SliceMutIter<'a, T> {}
 impl<'a, T: 'a> ExactSizeIterator for SliceMutIter<'a, T> {}
+/// Extends Index<> with methods to get segments and (segment,offset) tuples
+pub(crate) trait SegmentIndex<T>: Index<usize, Output = T> {
+    fn index(&self, i: usize) -> &T;
+    fn segment_and_offset(&self, i: usize) -> (usize, usize);
+    fn segment(&self, i: usize) -> &[T];
+}
+
+/// Extends SegmentIndex<> with methods for mutable access.
+pub(crate) trait SegmentIndexMut<T>: SegmentIndex<T> + IndexMut<usize, Output = T> {
+    fn index_mut(&mut self, i: usize) -> &mut T;
+    fn segment_mut(&mut self, i: usize) -> &mut [T];
+
+    // Downcasts `&SegmentIndexMut<T>` to `&SegmentIndex<T>`
+    fn as_segment_index(&self) -> &dyn SegmentIndex<T>;
+}
+
+impl<T, C: MemConfig> SegmentIndex<T> for SegVec<T, C> {
+    #[inline]
+    fn index(&self, i: usize) -> &T {
+        Index::index(self, i)
+    }
+
+    #[inline]
+    fn segment_and_offset(&self, i: usize) -> (usize, usize) {
+        self.config.segment_and_offset(i)
+    }
+
+    #[inline]
+    fn segment(&self, i: usize) -> &[T] {
+        &self.segments[i]
+    }
+}
+
+impl<T, C: MemConfig> SegmentIndexMut<T> for SegVec<T, C>
+where
+    Self: IndexMut<usize, Output = T>,
+{
+    #[inline]
+    fn index_mut(&mut self, i: usize) -> &mut T {
+        IndexMut::index_mut(self, i)
+    }
+
+    #[inline]
+    fn segment_mut(&mut self, i: usize) -> &mut [T] {
+        &mut self.segments[i]
+    }
+
+    #[inline]
+    fn as_segment_index(&self) -> &dyn SegmentIndex<T> {
+        self
+    }
+}
+
 fn slice_index_to_base_index(
     start_idx: usize,
     slice_idx: usize,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -129,7 +129,7 @@ impl<'a, T: 'a> Slice<'a, T> {
 impl<'a, T: 'a> Index<usize> for Slice<'a, T> {
     type Output = T;
 
-    fn index(&self, index: usize) -> &'a Self::Output {
+    fn index(&self, index: usize) -> &Self::Output {
         match slice_index_to_base_index(self.start, index, self.len) {
             Some(idx) => SegmentIndex::index(self.inner, idx),
             _ => index_oob("Slice::index", index, self.len),

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,5 +1,41 @@
 use crate::*;
 
+/// Extends Index<> with methods to get segments and (segment,offset) tuples
+pub(crate) trait SegmentIndex<T>: Index<usize, Output = T> {
+    fn index(&self, i: usize) -> &T;
+    fn index_mut(&mut self, i: usize) -> &mut T;
+    fn segment_and_offset(&self, i: usize) -> (usize, usize);
+    fn segment(&self, i: usize) -> &[T];
+    fn segment_mut(&mut self, i: usize) -> &mut [T];
+}
+
+impl<T, C: MemConfig> SegmentIndex<T> for SegVec<T, C> {
+    #[inline]
+    fn index(&self, i: usize) -> &T {
+        Index::index(self, i)
+    }
+
+    #[inline]
+    fn index_mut(&mut self, i: usize) -> &mut T {
+        IndexMut::index_mut(self, i)
+    }
+
+    #[inline]
+    fn segment_and_offset(&self, i: usize) -> (usize, usize) {
+        self.config.segment_and_offset(i)
+    }
+
+    #[inline]
+    fn segment(&self, i: usize) -> &[T] {
+        &self.segments[i]
+    }
+
+    #[inline]
+    fn segment_mut(&mut self, i: usize) -> &mut [T] {
+        &mut self.segments[i]
+    }
+}
+
 /// Provides an immutable view of elements from a range in [`SegVec`][crate::SegVec].
 pub struct Slice<'a, T: 'a> {
     inner: &'a (dyn SegmentIndex<T>),

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -38,7 +38,7 @@ impl<T, C: MemConfig> SegmentIndex<T> for SegVec<T, C> {
 
 /// Provides an immutable view of elements from a range in [`SegVec`][crate::SegVec].
 pub struct Slice<'a, T: 'a> {
-    inner: &'a (dyn SegmentIndex<T>),
+    inner: &'a dyn SegmentIndex<T>,
     start: usize,
     len: usize,
 }
@@ -72,6 +72,12 @@ impl<'a, T: 'a> Slice<'a, T> {
     #[inline]
     pub fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns true when a slice is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Returns an iterator over immutable references to the elements of the
@@ -111,7 +117,7 @@ impl<'a, T: 'a> Slice<'a, T> {
     /// - If the end index is greater than `self.len()`
     /// - If the start index is greater than the end index.
     pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> Self {
-        let (start, end) = bounds(self.len, "Slice::subslice", range);
+        let (start, end) = bounds(self.len, "Slice::slice", range);
         Slice {
             inner: self.inner,
             start: self.start + start,
@@ -241,6 +247,7 @@ impl<'a, T> DoubleEndedIterator for SegmentedIter<'a, T> {
         Some(ret)
     }
 }
+
 
 /// Provides a mutable view of elements from a range in [`SegVec`][crate::SegVec].
 pub struct SliceMut<'a, T: 'a> {

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,0 +1,300 @@
+use crate::*;
+
+/// Provides an immutable view of elements from a range in [`SegVec`][crate::SegVec].
+pub struct Slice<'a, T: 'a> {
+    inner: &'a (dyn SegmentIndex<T>),
+    start: usize,
+    len: usize,
+}
+
+impl<'a, T: 'a> Copy for Slice<'a, T> {}
+
+impl<'a, T: 'a> Clone for Slice<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: Debug + 'a> Debug for Slice<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl<'a, T: 'a> Slice<'a, T> {
+    // internal ctor
+    #[inline]
+    pub(crate) fn new(segvec: &'a dyn SegmentIndex<T>, start: usize, len: usize) -> Self {
+        Slice {
+            inner: segvec,
+            start,
+            len,
+        }
+    }
+
+    /// Returns the number of elements in the [`Slice`][crate::Slice].
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns an iterator over immutable references to the elements of the
+    /// [`Slice`][crate::Slice].
+    pub fn iter(&self) -> SliceIter<'a, T> {
+        SliceIter {
+            iter: self.segmented_iter().flatten(),
+            start: 0,
+            end: self.len,
+        }
+    }
+
+    /// Returns an iterator over immutable references of slices of elements of the
+    /// [`Slice`][crate::Slice].
+    pub fn segmented_iter(&self) -> SegmentedIter<'a, T> {
+        let start = self.inner.segment_and_offset(self.start);
+        // The 'end' is inclusive because we don't want to spill into the next segment. For an
+        // empty slice we have to prevent integer underflow, we just store a (0,0), this will
+        // not be used later since len is checked first to be not zero.
+        let end = if self.len > 0 {
+            self.inner.segment_and_offset(self.start + self.len - 1)
+        } else {
+            (0, 0)
+        };
+
+        SegmentedIter {
+            slice: *self,
+            start,
+            end,
+        }
+    }
+
+    /// Sub-slices an existing slice, returns a new [`Slice`][crate::Slice] covering the given
+    /// `range`.
+    ///
+    /// # Panics
+    /// - If the end index is greater than `self.len()`
+    /// - If the start index is greater than the end index.
+    pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> Self {
+        let (start, end) = bounds(self.len, "Slice::subslice", range);
+        Slice {
+            inner: self.inner,
+            start: self.start + start,
+            len: end - start,
+        }
+    }
+}
+
+impl<'a, T: 'a> Index<usize> for Slice<'a, T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &'a Self::Output {
+        match slice_index_to_base_index(self.start, index, self.len) {
+            Some(idx) => SegmentIndex::index(self.inner, idx),
+            _ => index_oob("Slice::index", index, self.len),
+        }
+    }
+}
+
+impl<'a, T: 'a> IntoIterator for Slice<'a, T> {
+    type IntoIter = SliceIter<'a, T>;
+    type Item = &'a T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over immutable references to the elements of a [`Slice`][crate::Slice].
+pub struct SliceIter<'a, T: 'a> {
+    iter: Flatten<SegmentedIter<'a, T>>,
+    // Since Flatten is opaque we have to do our own accounting for size_hint here.
+    start: usize,
+    end: usize,
+}
+
+impl<'a, T: 'a> Iterator for SliceIter<'a, T> {
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.end > self.start {
+            self.start += 1;
+            self.iter.next()
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = self.end - self.start;
+        (left, Some(left))
+    }
+}
+
+impl<'a, T: 'a> FusedIterator for SliceIter<'a, T> {}
+impl<'a, T: 'a> ExactSizeIterator for SliceIter<'a, T> {}
+
+impl<'a, T> DoubleEndedIterator for SliceIter<'a, T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.end > self.start {
+            self.end -= 1;
+            self.iter.next_back()
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over immutable references to slices of the elements of a [`Slice`][crate::Slice].
+pub struct SegmentedIter<'a, T: 'a> {
+    slice: Slice<'a, T>,
+    start: (usize, usize),
+    end: (usize, usize),
+}
+
+impl<'a, T: 'a> Iterator for SegmentedIter<'a, T> {
+    type Item = &'a [T];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // We never return an empty slice
+        if self.slice.len == 0 || self.start.0 > self.end.0 {
+            return None;
+        }
+
+        let ret = if self.start.0 == self.end.0 {
+            &self.slice.inner.segment(self.start.0)[self.start.1..=self.end.1]
+        } else {
+            &self.slice.inner.segment(self.start.0)[self.start.1..]
+        };
+        self.start = (self.start.0 + 1, 0);
+        Some(ret)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = 1 + self.end.0 - self.start.0;
+        (left, Some(left))
+    }
+}
+
+impl<'a, T: 'a> FusedIterator for SegmentedIter<'a, T> {}
+impl<'a, T: 'a> ExactSizeIterator for SegmentedIter<'a, T> {}
+
+impl<'a, T> DoubleEndedIterator for SegmentedIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // We never return an empty slice
+        if self.slice.len == 0 || self.start.0 > self.end.0 {
+            return None;
+        }
+
+        let ret = if self.start.0 == self.end.0 {
+            &self.slice.inner.segment(self.end.0)[self.start.1..=self.end.1]
+        } else {
+            &self.slice.inner.segment(self.end.0)[..=self.end.1]
+        };
+        // need to be careful not to underflow self.end.0 when done.
+        if self.end.0 != 0 {
+            self.end = (
+                self.end.0 - 1,
+                self.slice.inner.segment(self.end.0 - 1).len() - 1,
+            );
+        } else {
+            // with start.0 > end.0 the iterator is flagged as 'done'
+            self.start = (1, 0);
+        }
+        Some(ret)
+    }
+}
+
+/// Provides a mutable view of elements from a range in [`SegVec`][crate::SegVec].
+pub struct SliceMut<'a, T: 'a> {
+    inner: &'a mut dyn IndexMut<usize, Output = T>,
+    start: usize,
+    len: usize,
+}
+
+impl<'a, T: 'a> SliceMut<'a, T> {
+    // internal ctor
+    #[inline]
+    pub(crate) fn new(
+        segvec: &'a mut dyn IndexMut<usize, Output = T>,
+        start: usize,
+        len: usize,
+    ) -> Self {
+        SliceMut {
+            inner: segvec,
+            start,
+            len,
+        }
+    }
+
+    /// Returns the number of elements in the [`SliceMut`][crate::SliceMut].
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<'a, T: 'a> Index<usize> for SliceMut<'a, T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        match slice_index_to_base_index(self.start, index, self.len) {
+            Some(idx) => self.inner.index(idx),
+            _ => index_oob("SliceMut::index", index, self.len),
+        }
+    }
+}
+
+impl<'a, T: 'a> IndexMut<usize> for SliceMut<'a, T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match slice_index_to_base_index(self.start, index, self.len) {
+            Some(idx) => self.inner.index_mut(idx),
+            _ => index_oob("SliceMut::index_mut", index, self.len),
+        }
+    }
+}
+
+impl<'a, T: 'a> IntoIterator for SliceMut<'a, T> {
+    type IntoIter = SliceMutIter<'a, T>;
+    type Item = &'a mut T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SliceMutIter {
+            slice: self,
+            index: 0,
+        }
+    }
+}
+
+/// Iterator over mutable references to the elements of a [`SliceMut`][crate::SliceMut].
+pub struct SliceMutIter<'a, T: 'a> {
+    slice: SliceMut<'a, T>,
+    index: usize,
+}
+
+impl<'a, T: 'a> Iterator for SliceMutIter<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.slice.len {
+            let index = self.index;
+            self.index += 1;
+            // SAFETY:
+            // 1. index corresponds to a valid value in the slice
+            // 2. the value at index must live for at least the lifetime 'a
+            // 3. from #1+2, it is known that a taking an &'a mut to the value in the
+            //    slice is safe
+            Some(unsafe { &mut *(self.slice.index_mut(index) as *mut T) })
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = self.slice.len - self.index;
+        (left, Some(left))
+    }
+}
+
+impl<'a, T: 'a> FusedIterator for SliceMutIter<'a, T> {}
+impl<'a, T: 'a> ExactSizeIterator for SliceMutIter<'a, T> {}

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,4 +1,6 @@
 use crate::*;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
 
 /// Provides an immutable view of elements from a range in [`SegVec`][crate::SegVec].
 pub struct Slice<'a, T: 'a> {
@@ -234,19 +236,21 @@ impl<'a, T: 'a> DoubleEndedIterator for SegmentedIter<'a, T> {
 
 /// Provides a mutable view of elements from a range in [`SegVec`][crate::SegVec].
 pub struct SliceMut<'a, T: 'a> {
-    inner: &'a mut dyn IndexMut<usize, Output = T>,
+    inner: &'a mut dyn SegmentIndexMut<T>,
     start: usize,
     len: usize,
 }
 
+impl<'a, T: Clone + Debug + 'a> Debug for SliceMut<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
 impl<'a, T: 'a> SliceMut<'a, T> {
-    // internal ctor
+    // private ctor
     #[inline]
-    pub(crate) fn new(
-        segvec: &'a mut dyn IndexMut<usize, Output = T>,
-        start: usize,
-        len: usize,
-    ) -> Self {
+    pub(crate) fn new(segvec: &'a mut dyn SegmentIndexMut<T>, start: usize, len: usize) -> Self {
         SliceMut {
             inner: segvec,
             start,
@@ -255,9 +259,114 @@ impl<'a, T: 'a> SliceMut<'a, T> {
     }
 
     /// Returns the number of elements in the [`SliceMut`][crate::SliceMut].
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
+
+    /// Returns true when a slice is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns an iterator over immutable references to the elements of the
+    /// [`SliceMut`][crate::SliceMut].
+    pub fn iter(&self) -> SliceIter<'_, T> {
+        let end = self.len;
+
+        SliceIter {
+            iter: self.segmented_iter().flatten(),
+            start: 0,
+            end,
+        }
+    }
+
+    /// Returns an iterator over mutable references to the elements of the
+    /// [`SliceMut`][crate::SliceMut].
+    pub fn iter_mut(&mut self) -> SliceMutIter<'a, T> {
+        let end = self.len;
+        SliceMutIter {
+            iter: self.segmented_iter_mut().flatten(),
+            start: 0,
+            end,
+        }
+    }
+
+    /// Returns an iterator over immutable references of slices of elements of the
+    /// [`SliceMut`][crate::SliceMut].
+    pub fn segmented_iter(&self) -> SegmentedIter<'_, T> {
+        let start = self.inner.segment_and_offset(self.start);
+        // The 'end' is inclusive because we don't want to spill into the next segment. For an
+        // empty slice we have to prevent integer underflow, we just store a (0,0), this will
+        // not be used later since len is checked first to be not zero.
+        let end = if self.len > 0 {
+            self.inner.segment_and_offset(self.start + self.len - 1)
+        } else {
+            (0, 0)
+        };
+
+        let slice = Slice {
+            inner: self.inner.as_segment_index(),
+            start: self.start,
+            len: self.len,
+        };
+
+        SegmentedIter { slice, start, end }
+    }
+
+    /// Returns an iterator over immutable references of slices of elements of the
+    /// [`SliceMut`][crate::SliceMut].
+    pub fn segmented_iter_mut(&mut self) -> SegmentedMutIter<'a, T> {
+        let start = self.inner.segment_and_offset(self.start);
+        // The 'end' is inclusive because we don't want to spill into the next segment. For an
+        // empty slice we have to prevent integer underflow, we just store a (0,0), this will
+        // not be used later since len is checked first to be not zero.
+        let end = if self.len > 0 {
+            self.inner.segment_and_offset(self.start + self.len - 1)
+        } else {
+            (0, 0)
+        };
+
+        SegmentedMutIter {
+            slice: self.into(),
+            start,
+            end,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Sub-slices an existing 'SliceMut', returns a new [`Slice`][crate::Slice] covering the given
+    /// `range`.
+    ///
+    /// # Panics
+    /// - If the end index is greater than `self.len()`
+    /// - If the start index is greater than the end index.
+    pub fn slice<R: RangeBounds<usize>>(&'a self, range: R) -> Slice<'a, T> {
+        let (start, end) = bounds(self.len, "SliceMut::slice", range);
+        Slice {
+            inner: self.inner.as_segment_index(),
+            start: self.start + start,
+            len: end - start,
+        }
+    }
+
+    /// Sub-slices an existing 'SliceMut', returns a new [`SliceMut`][crate::SliceMut] covering the given
+    /// `range`.
+    ///
+    /// # Panics
+    /// - If the end index is greater than `self.len()`
+    /// - If the start index is greater than the end index.
+    pub fn slice_mut<R: RangeBounds<usize>>(&'a mut self, range: R) -> SliceMut<'a, T> {
+        let (start, end) = bounds(self.len, "SliceMut::slice_mut", range);
+        SliceMut {
+            inner: self.inner,
+            start: self.start + start,
+            len: end - start,
+        }
+    }
+
+    // PLANNED: split_at_mut()
 }
 
 impl<'a, T: 'a> Index<usize> for SliceMut<'a, T> {
@@ -265,7 +374,7 @@ impl<'a, T: 'a> Index<usize> for SliceMut<'a, T> {
 
     fn index(&self, index: usize) -> &Self::Output {
         match slice_index_to_base_index(self.start, index, self.len) {
-            Some(idx) => self.inner.index(idx),
+            Some(idx) => SegmentIndex::index(self.inner, idx),
             _ => index_oob("SliceMut::index", index, self.len),
         }
     }
@@ -274,56 +383,127 @@ impl<'a, T: 'a> Index<usize> for SliceMut<'a, T> {
 impl<'a, T: 'a> IndexMut<usize> for SliceMut<'a, T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         match slice_index_to_base_index(self.start, index, self.len) {
-            Some(idx) => self.inner.index_mut(idx),
+            Some(idx) => SegmentIndexMut::index_mut(self.inner, idx),
             _ => index_oob("SliceMut::index_mut", index, self.len),
         }
     }
 }
 
-impl<'a, T: 'a> IntoIterator for SliceMut<'a, T> {
-    type IntoIter = SliceMutIter<'a, T>;
-    type Item = &'a mut T;
-
-    fn into_iter(self) -> Self::IntoIter {
-        SliceMutIter {
-            slice: self,
-            index: 0,
-        }
-    }
-}
-
-/// Iterator over mutable references to the elements of a [`SliceMut`][crate::SliceMut].
+/// Iterator over immutable references to the elements of a [`SliceMut`][crate::SliceMut].
 pub struct SliceMutIter<'a, T: 'a> {
-    slice: SliceMut<'a, T>,
-    index: usize,
+    iter: Flatten<SegmentedMutIter<'a, T>>,
+    // Since Flatten's size_hint is not sufficient we have to do our own accounting here.
+    start: usize,
+    end: usize,
 }
 
 impl<'a, T: 'a> Iterator for SliceMutIter<'a, T> {
     type Item = &'a mut T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index < self.slice.len {
-            let index = self.index;
-            self.index += 1;
-            // SAFETY:
-            // 1. index corresponds to a valid value in the slice
-            // 2. the value at index must live for at least the lifetime 'a
-            // 3. from #1+2, it is known that a taking an &'a mut to the value in the
-            //    slice is safe
-            Some(unsafe { &mut *(self.slice.index_mut(index) as *mut T) })
+        if self.end > self.start {
+            self.start += 1;
+            self.iter.next()
         } else {
             None
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let left = self.slice.len - self.index;
+        let left = self.end - self.start;
         (left, Some(left))
     }
 }
 
 impl<'a, T: 'a> FusedIterator for SliceMutIter<'a, T> {}
 impl<'a, T: 'a> ExactSizeIterator for SliceMutIter<'a, T> {}
+
+impl<'a, T: 'a> DoubleEndedIterator for SliceMutIter<'a, T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.end > self.start {
+            self.end -= 1;
+            self.iter.next_back()
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over mutable references to slices of the elements of a [`SliceMut`][crate::SliceMut].
+pub struct SegmentedMutIter<'a, T: 'a> {
+    // Safety:
+    // We can not use a reference here because aliasing rules and `fn next(&self)` would
+    // introduce a lifetime on 'self while we keep 'a here. Using a pointer here will use the
+    // correctly erased lifetime when dereferencing it in `next()`. By constructing this
+    // Iterator from a &mut we ensure that there can be only one iterator, thus the pointer is
+    // non aliased.
+    //
+    // Prior art: https://doc.rust-lang.org/std/slice/struct.ChunksMut.html
+    slice: NonNull<SliceMut<'a, T>>,
+    start: (usize, usize),
+    end: (usize, usize),
+    _marker: PhantomData<&'a mut T>,
+}
+
+impl<'a, T: 'a> Iterator for SegmentedMutIter<'a, T> {
+    type Item = &'a mut [T];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // SAFETY: this pointer is always initialized to a valid and non-aliased reference.
+        let slice = unsafe { self.slice.as_mut() };
+
+        // We never return an empty slice
+        if slice.len == 0 || self.start.0 > self.end.0 {
+            return None;
+        }
+
+        let ret = if self.start.0 == self.end.0 {
+            &mut slice.inner.segment_mut(self.start.0)[self.start.1..=self.end.1]
+        } else {
+            &mut slice.inner.segment_mut(self.start.0)[self.start.1..]
+        };
+        self.start = (self.start.0 + 1, 0);
+        Some(ret)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = 1 + self.end.0 - self.start.0;
+        (left, Some(left))
+    }
+}
+
+impl<'a, T: 'a> FusedIterator for SegmentedMutIter<'a, T> {}
+impl<'a, T: 'a> ExactSizeIterator for SegmentedMutIter<'a, T> {}
+
+impl<'a, T: 'a> DoubleEndedIterator for SegmentedMutIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // SAFETY: this pointer is always initialized to a valid and non-aliased reference.
+        let slice = unsafe { self.slice.as_mut() };
+
+        let start = (self.start.0, self.start.1);
+        let end = (self.end.0, self.end.1);
+
+        // need to be careful not to underflow self.end.0 when done.
+        if end.0 != 0 {
+            self.end = (end.0 - 1, slice.inner.segment(end.0 - 1).len() - 1);
+        } else {
+            // with start.0 > end.0 the iterator is flagged as 'done'
+            self.start = (1, 0);
+        }
+
+        // We never return an empty slice
+        if slice.len == 0 || start.0 > end.0 {
+            None
+        } else if start.0 == end.0 {
+            Some(&mut slice.inner.segment_mut(end.0)[self.start.1..=end.1])
+        } else {
+            Some(&mut slice.inner.segment_mut(end.0)[..=end.1])
+        }
+    }
+}
+
 /// Extends Index<> with methods to get segments and (segment,offset) tuples
 pub(crate) trait SegmentIndex<T>: Index<usize, Output = T> {
     fn index(&self, i: usize) -> &T;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -341,3 +341,13 @@ impl<'a, T: 'a> Iterator for SliceMutIter<'a, T> {
 
 impl<'a, T: 'a> FusedIterator for SliceMutIter<'a, T> {}
 impl<'a, T: 'a> ExactSizeIterator for SliceMutIter<'a, T> {}
+fn slice_index_to_base_index(
+    start_idx: usize,
+    slice_idx: usize,
+    slice_len: usize,
+) -> Option<usize> {
+    match start_idx.checked_add(slice_idx) {
+        Some(idx) if idx - start_idx < slice_len => Some(idx),
+        _ => None,
+    }
+}

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -471,6 +471,7 @@ pub struct SegmentedMutIter<'a, T: 'a> {
     // SliceMut in case of a `IntoIter`.
     //
     // Prior art: https://doc.rust-lang.org/std/slice/struct.ChunksMut.html
+    #[allow(clippy::type_complexity)]
     slice: Either<(NonNull<SliceMut<'a, T>>, PhantomData<&'a mut T>), SliceMut<'a, T>>,
     start: (usize, usize),
     end: (usize, usize),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -377,6 +377,17 @@ fn test_slice() {
     assert_eq!(s6.iter().copied().collect::<Vec<i32>>(), vec![]);
 }
 
+// this must not compile
+// #[test]
+// fn test_slice_lifetime() {
+//     let mut v = SegVec::<i32>::new();
+//     v.push(1);
+//     let s = v.slice(..);
+//     // drop v while using s later
+//     drop(v);
+//     assert_eq!(s[0], 1);
+// }
+
 #[test]
 fn test_subslice() {
     let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
@@ -512,6 +523,23 @@ fn test_slice_iter() {
     assert_eq!(iter.size_hint(), (0, Some(0)));
 
     assert_eq!(s.len(), 7);
+}
+
+#[test]
+fn test_slice_into_iter() {
+    let mut v = SegVec::<i32, Exponential<1>>::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+
+    let i = v.slice(..).into_iter();
+
+    assert_eq!(i.size_hint(), (7, Some(7)));
+    assert_eq!(i.copied().collect::<Vec<_>>(), vec![1, 2, 3, 4, 5, 6, 7]);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -493,27 +493,25 @@ fn test_slice_iter() {
         s.iter().copied().collect::<Vec<_>>(),
         vec![1, 2, 3, 4, 5, 6, 7]
     );
-    // PLANNED: DoubleEndedIterator for SliceIter
-    // assert_eq!(
-    //     s.iter().rev().copied().collect::<Vec<_>>(),
-    //     vec![7, 6, 5, 4, 3, 2, 1]
-    // );
+    assert_eq!(
+        s.iter().rev().copied().collect::<Vec<_>>(),
+        vec![7, 6, 5, 4, 3, 2, 1]
+    );
 
     let mut iter = s.iter();
     assert_eq!(iter.next().unwrap(), &1);
-    // PLANNED: assert_eq!(iter.next_back().unwrap(), &7);
-    assert_eq!(iter.size_hint(), (6, Some(6)));
-    assert_eq!(iter.next().unwrap(), &2);
-    // PLANNED: assert_eq!(iter.next_back().unwrap(), &6);
+    assert_eq!(iter.next_back().unwrap(), &7);
     assert_eq!(iter.size_hint(), (5, Some(5)));
+    assert_eq!(iter.next().unwrap(), &2);
+    assert_eq!(iter.next_back().unwrap(), &6);
+    assert_eq!(iter.size_hint(), (3, Some(3)));
     assert_eq!(iter.next().unwrap(), &3);
-    // PLANNED: assert_eq!(iter.next_back().unwrap(), &5);
-    assert_eq!(iter.size_hint(), (4, Some(4)));
-    // PLANNED: assert_eq!(iter.next_back().unwrap(), &4);
-    //assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.next_back().unwrap(), &5);
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+    assert_eq!(iter.next_back().unwrap(), &4);
+    assert_eq!(iter.size_hint(), (0, Some(0)));
 
     assert_eq!(s.len(), 7);
-    // PLANNED: assert_eq!(v.capacity(), 8);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -452,6 +452,34 @@ fn test_subslice() {
 // }
 
 #[test]
+fn from_slice() {
+    let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+    v.push(8);
+    let slice = v.slice(..);
+    assert_eq!(
+        slice.iter().copied().collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5, 6, 7, 8]
+    );
+
+    let subslice = slice.slice(2..5);
+    assert_eq!(subslice.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+
+    let v2 = SegVec::<_, Exponential<1>>::from(&subslice);
+    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+
+    // can be used to change the MemConfig as well
+    let v2 = SegVec::<_, Linear<4>>::from(subslice);
+    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+}
+
+#[test]
 fn test_slice_mut() {
     let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
     v.push(1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -474,13 +474,36 @@ fn test_slice_mut() {
     v.push(7);
     v.push(8);
     let mut s = v.slice_mut(..);
+    assert_eq!(s[7], 8);
     // invalid:
     // v.push(1000); // <- SliceMuts mutably borrow the underlying SegVec
     s[0] = 100;
-    s.into_iter().for_each(|v| *v *= 2);
+    s.iter_mut().for_each(|v| *v *= 2);
+    // TODO: s.into_iter().for_each(|v| *v *= 2);
     assert_eq!(
-        v.into_iter().collect::<Vec<_>>(),
+        v.iter().copied().collect::<Vec<_>>(),
         vec![200, 4, 6, 8, 10, 12, 14, 16]
+    );
+}
+
+#[test]
+fn test_slice_iter_mut() {
+    let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+    v.push(8);
+    let mut s = v.slice_mut(..);
+    s.iter_mut().for_each(|v| *v *= 2);
+    s.iter_mut().for_each(|v| *v *= 2);
+
+    assert_eq!(
+        s.iter().copied().collect::<Vec<_>>(),
+        vec![4, 8, 12, 16, 20, 24, 28, 32]
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -452,34 +452,6 @@ fn test_subslice() {
 // }
 
 #[test]
-fn from_slice() {
-    let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
-    v.push(1);
-    v.push(2);
-    v.push(3);
-    v.push(4);
-    v.push(5);
-    v.push(6);
-    v.push(7);
-    v.push(8);
-    let slice = v.slice(..);
-    assert_eq!(
-        slice.iter().copied().collect::<Vec<_>>(),
-        vec![1, 2, 3, 4, 5, 6, 7, 8]
-    );
-
-    let subslice = slice.slice(2..5);
-    assert_eq!(subslice.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
-
-    let v2 = SegVec::<_, Exponential<1>>::from(&subslice);
-    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
-
-    // can be used to change the MemConfig as well
-    let v2 = SegVec::<_, Linear<4>>::from(subslice);
-    assert_eq!(v2.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
-}
-
-#[test]
 fn test_slice_mut() {
     let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
     v.push(1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -479,10 +479,10 @@ fn test_slice_mut() {
     // v.push(1000); // <- SliceMuts mutably borrow the underlying SegVec
     s[0] = 100;
     s.iter_mut().for_each(|v| *v *= 2);
-    // TODO: s.into_iter().for_each(|v| *v *= 2);
+    s.into_iter().for_each(|v| *v *= 2);
     assert_eq!(
         v.iter().copied().collect::<Vec<_>>(),
-        vec![200, 4, 6, 8, 10, 12, 14, 16]
+        vec![400, 8, 12, 16, 20, 24, 28, 32]
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -508,6 +508,27 @@ fn test_slice_iter_mut() {
 }
 
 #[test]
+fn test_slice_mut_into_iter() {
+    let mut v = SegVec::<_, Exponential<1>>::with_capacity(8);
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    v.push(6);
+    v.push(7);
+    v.push(8);
+    let mut s = v.slice_mut(..);
+    s[0] = 100;
+    s.into_iter().for_each(|v| *v *= 2);
+
+    assert_eq!(
+        v.into_iter().collect::<Vec<_>>(),
+        vec![200, 4, 6, 8, 10, 12, 14, 16]
+    );
+}
+
+#[test]
 fn test_slice_iter() {
     let mut v = SegVec::<i32, Exponential<1>>::new();
     v.push(1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -538,6 +538,12 @@ fn test_segmented_iter() {
     assert_eq!(iter.next().unwrap(), &[3, 4]);
     assert_eq!(iter.next().unwrap(), &[5, 6, 7]);
     assert_eq!(iter.size_hint(), (0, Some(0)));
+
+    let mut iter = v.slice(..).segmented_iter();
+    assert_eq!(iter.next_back().unwrap(), &[5, 6, 7]);
+    assert_eq!(iter.next_back().unwrap(), &[3, 4]);
+    assert_eq!(iter.next_back().unwrap(), &[2]);
+    assert_eq!(iter.next_back().unwrap(), &[1]);
 }
 
 #[test]


### PR DESCRIPTION
Turns out that I'll need a IterMut as well, thus I started with some cleanup and implementing the missing bits on Slice iterators. WIP still.

Done:
 - DoubleEndedIterator for SliceIter/SegmentedIter
 - Factored the Slice stuff into slice.rs

Upcoming:
 - The same for *Mut variants
 - Factor the iterators into a 'iter.rs'
 - Likely: remove SegVec::Iter, rename SliceIter to just Iter, make Slice::iter() use that. That simplifies the Codebase with little to no performance impact. (Same for the *Mut) variants.