### PR TITLE
Enable miri in CI

### DIFF
--- a/.github/workflows/rust-build-and-test.yml
+++ b/.github/workflows/rust-build-and-test.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-stable:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-          components: rustfmt, clippy, miri
+          components: rustfmt, clippy
       - name: Run cargo check
         run: |
           cargo check --verbose;
@@ -32,4 +32,29 @@ jobs:
           cargo test --features small-vec --verbose;
           cargo test --features thin-segments --verbose;
           cargo test --features small-vec --features thin-segments --verbose;
-          cargo miri test --verbose;
+  build-nightly:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Install Rust
+          uses: actions-rs/toolchain@v1
+          with:
+            toolchain: nightly
+            override: true
+            components: rustfmt, clippy, miri
+        - name: Run cargo check
+          run: |
+            cargo check --verbose;
+            cargo check --features small-vec --verbose;
+            cargo check --features thin-segments --verbose;
+            cargo check --features small-vec --features thin-segments --verbose;
+        - name: Run tests
+          run: |
+            cargo test --verbose;
+            cargo miri test --verbose;
+            cargo test --features small-vec --verbose;
+            cargo miri test --features small-vec --verbose;
+            cargo test --features thin-segments --verbose;
+            cargo miri test --features thin-segments --verbose;
+            cargo test --features small-vec --features thin-segments --verbose;
+            cargo miri test --features small-vec --features thin-segments --verbose;

--- a/.github/workflows/rust-build-and-test.yml
+++ b/.github/workflows/rust-build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-          components: rustfmt, clippy
+          components: rustfmt, clippy, miri
       - name: Run cargo check
         run: |
           cargo check --verbose;
@@ -32,3 +32,4 @@ jobs:
           cargo test --features small-vec --verbose;
           cargo test --features thin-segments --verbose;
           cargo test --features small-vec --features thin-segments --verbose;
+          cargo miri test --verbose;

--- a/.github/workflows/rust-build-and-test.yml
+++ b/.github/workflows/rust-build-and-test.yml
@@ -53,8 +53,5 @@ jobs:
             cargo test --verbose;
             cargo miri test --verbose;
             cargo test --features small-vec --verbose;
-            cargo miri test --features small-vec --verbose;
             cargo test --features thin-segments --verbose;
-            cargo miri test --features thin-segments --verbose;
             cargo test --features small-vec --features thin-segments --verbose;
-            cargo miri test --features small-vec --features thin-segments --verbose;


### PR DESCRIPTION
Enable very basic `miri` support to CI. Only runs tests with the default features under `miri`, but its a start.