### PR TITLE
add `as_contiguous` to `Slice`

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -94,7 +94,7 @@ impl<'a, T: 'a> Slice<'a, T> {
 
     /// Tries to treat this SegVec [`Slice`] as a contiguous [`slice`]. This only
     /// succeeds if all the elements of this [`Slice`] are in the same segment.
-    pub fn as_contiguous(&self) -> Option<&[T]> {
+    pub fn as_contiguous(&self) -> Option<&'a [T]> {
         let (start_segment, start_offset) = self.inner.segment_and_offset(self.start);
 
         if self.len == 0 {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -768,3 +768,36 @@ fn test_not_thin_segments_feature() {
     let _: detail::Segment<()> = Vec::new();
 }
 
+#[test]
+fn test_slice_as_contiguous() {
+    let mut sv: SegVec<i32, Linear<4>> = SegVec::with_capacity(4);
+
+    // first segment
+    sv.push(0);
+    sv.push(1);
+    sv.push(2);
+    sv.push(3);
+
+    // second segment
+    sv.push(4);
+    sv.push(5);
+    sv.push(6);
+    sv.push(7);
+
+    assert_eq!(sv.slice(2..2).as_contiguous(), Some([].as_slice()));
+
+    assert_eq!(
+        sv.slice(0..4).as_contiguous(),
+        Some([0, 1, 2, 3].as_slice())
+    );
+    assert_eq!(sv.slice(1..3).as_contiguous(), Some([1, 2].as_slice()));
+
+    assert!(sv.slice(0..5).as_contiguous().is_none());
+    assert!(sv.slice(3..8).as_contiguous().is_none());
+
+    assert_eq!(
+        sv.slice(4..8).as_contiguous(),
+        Some([4, 5, 6, 7].as_slice())
+    );
+    assert_eq!(sv.slice(5..7).as_contiguous(), Some([5, 6].as_slice()));
+}


### PR DESCRIPTION
adds a method to attempt turning a SegVec `Slice` (which is not necessarily contiguous) into a `&[T]` that can be useful whenever the `Slice` only spans a single segment.