### PR TITLE
impl `io::Write` for `SegVec<u8>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -920,6 +920,19 @@ impl<T: Debug, C: MemConfig> Debug for SegVec<T, C> {
     }
 }
 
+impl<C: MemConfig> std::io::Write for SegVec<u8, C> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 impl<T: Hash, C: MemConfig> Hash for SegVec<T, C> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.iter().for_each(|i| i.hash(state));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -828,3 +828,18 @@ fn test_extend_from_slice() {
         assert_eq!(v, &elements[i % elements.len()]);
     }
 }
+
+#[test]
+fn test_write() {
+    use std::io::Write;
+
+    let mut sv: SegVec<u8> = SegVec::new();
+
+    let string = "hello from write_fmt in a segvec!";
+    sv.write_fmt(format_args!("{}", string)).unwrap();
+
+    assert_eq!(string.len(), sv.len());
+    for (a, b) in string.as_bytes().iter().zip(sv.iter()) {
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
very straightforward implementation of the `write` trait