### PR TITLE
add `extend_from_slice` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -831,6 +831,11 @@ impl<T, C: MemConfig> SegVec<T, C> {
         }
     }
 
+    /// Clones and appends all elements in a slice to the `SegVec`.
+    ///
+    /// Iterates over the slice, clones each element, and then appends it to this `SegVec`. The slice is traversed in-order.
+    ///
+    /// Note that this function is same as `extend` except that it is specialized to work with slices instead.
     pub fn extend_from_slice(&mut self, mut slice: &[T])
     where
         T: Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -944,12 +944,16 @@ impl<T, C: MemConfig> Extend<T> for SegVec<T, C> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
         let (min_size, max_size) = iter.size_hint();
-        let additional = std::cmp::max(max_size.unwrap_or(0), min_size);
-        self.reserve(additional);
-        for i in iter {
-            // SAFETY: we just reserved space for these elements
-            unsafe {
-                self.push_unchecked(i);
+        let hint_count = std::cmp::max(max_size.unwrap_or(0), min_size);
+        self.reserve(hint_count);
+        for (index, elem) in iter.enumerate() {
+            if index < hint_count {
+                // SAFETY: we just reserved space for these elements
+                unsafe {
+                    self.push_unchecked(elem);
+                }
+            } else {
+                self.push(elem);
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use rand::{self, Rng};
+use rand::{self, Fill, Rng};
 use std::{cell::Cell, collections::hash_map::DefaultHasher, hash::Hasher};
 
 struct DropCount<'a, T: Copy>(&'a Cell<usize>, T);
@@ -800,4 +800,31 @@ fn test_slice_as_contiguous() {
         Some([4, 5, 6, 7].as_slice())
     );
     assert_eq!(sv.slice(5..7).as_contiguous(), Some([5, 6].as_slice()));
+}
+
+#[test]
+fn test_extend_from_slice() {
+    let mut elements = [0u32; 100];
+    elements.try_fill(&mut rand::thread_rng()).unwrap();
+
+    // single iter
+    let mut sv: SegVec<u32> = SegVec::new();
+    sv.extend_from_slice(elements.as_slice());
+
+    assert_eq!(elements.len(), sv.len());
+    for (a, b) in elements.iter().zip(sv.iter()) {
+        assert_eq!(a, b);
+    }
+
+    // multiple iterations
+    let mut sv: SegVec<u32> = SegVec::new();
+
+    for _ in 0..8 {
+        sv.extend_from_slice(elements.as_slice());
+    }
+
+    assert_eq!(8 * elements.len(), sv.len());
+    for (a, b) in elements.iter().zip(sv.iter()) {
+        assert_eq!(a, b);
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -824,7 +824,7 @@ fn test_extend_from_slice() {
     }
 
     assert_eq!(8 * elements.len(), sv.len());
-    for (a, b) in elements.iter().zip(sv.iter()) {
-        assert_eq!(a, b);
+    for (i, v) in sv.iter().enumerate() {
+        assert_eq!(v, &elements[i % elements.len()]);
     }
 }


### PR DESCRIPTION
adds an `extend_from_slice` method to SegVec (and fixes a small bug in `extend` - it was reserving elements _twice_).

needed for acceptable performance in #40