### PR TITLE
Some minor cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,16 @@ repository = "https://github.com/mccolljr/segvec/"
 description = "SegVec data structure for rust. Similar to Vec, but allocates memory in chunks of increasing size"
 
 [dev-dependencies]
-rand = "0.8.4"
+rand = "0.8.5"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [dependencies]
-smallvec = { version = "1.10.0", features = ["const_generics", "union"], optional = true }
-thin-vec = { version = "0.2.3", optional = true }
+smallvec = { version = "1.11.2", features = ["const_generics", "union"], optional = true }
 num-integer = "0.1.45"
-either = "1.8.1"
+either = "1.9.0"
 
 [features]
 small-vec = ["smallvec"]
-thin-segments = ["thin-vec"]
 
 [[bench]]
 name = "segvec_benchmark"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 //! ## Features
 //!
 //! - `small-vec` - Uses [`SmallVec`](https://github.com/servo/rust-smallvec) instead of `Vec` to store the list of segments, allowing the first few segment headers to live on the stack. Can speed up access for small `SegVec` values.
-//! - `thin-segments` - Uses [`ThinVec`](https://github.com/Gankra/thin-vec) instead of `Vec` to store the data for each segment, meaning that each segment header takes up the space of a single `usize`, rathern than 3 when using `Vec`.
 
 #![allow(clippy::comparison_chain)]
 
@@ -41,9 +40,6 @@ mod slice;
 pub use slice::*;
 
 pub mod detail {
-    #[cfg(feature = "thin-segments")]
-    pub type Segment<T> = thin_vec::ThinVec<T>;
-    #[cfg(not(feature = "thin-segments"))]
     pub type Segment<T> = Vec<T>;
 
     #[cfg(feature = "small-vec")]

--- a/src/mem_config.rs
+++ b/src/mem_config.rs
@@ -344,19 +344,19 @@ pub fn exponential_segment_and_offset() {
 // Expensive tests (hopefully) catching off by one errors, need to be explicitly enabled
 
 #[test]
-#[ignore]
+#[cfg_attr(miri, ignore)]
 pub fn linear() {
     type DuT = Linear<64>;
 
     // segments
     let mut sum = 0_usize;
-    for i in 0..10000000000 {
+    for i in 0..10000000 {
         sum += DuT::new().segment_size(i);
         assert_eq!(DuT::new().capacity(i + 1), sum)
     }
 
     // indices
-    for i in 1..10000000000 {
+    for i in 1..10000000 {
         let (segment, index) = DuT::new().segment_and_offset(i);
         assert!(index < DuT::new().segment_size(segment));
         if index == 0 {
@@ -368,19 +368,19 @@ pub fn linear() {
 }
 
 #[test]
-#[ignore]
+#[cfg_attr(miri, ignore)]
 pub fn proportional() {
     type DuT = Proportional<4>;
 
     // segments
     let mut sum = 0_usize;
-    for i in 0..1000000000 {
+    for i in 0..10000000 {
         sum += DuT::new().segment_size(i);
         assert_eq!(DuT::new().capacity(i + 1), sum)
     }
 
     // indices
-    for i in 1..10000000000 {
+    for i in 1..10000000 {
         let (segment, index) = DuT::new().segment_and_offset(i);
         assert!(index < DuT::new().segment_size(segment));
         if index == 0 {
@@ -392,7 +392,7 @@ pub fn proportional() {
 }
 
 #[test]
-#[ignore]
+#[cfg_attr(miri, ignore)]
 pub fn exponential() {
     type DuT = Exponential<4>;
 
@@ -400,11 +400,13 @@ pub fn exponential() {
     let mut sum = 0_usize;
     for i in 0..60 {
         sum += DuT::new().segment_size(i);
-        assert_eq!(DuT::new().capacity(i + 1), sum)
+        let mut e = DuT::new();
+        e.update_capacity(i + 1);
+        assert_eq!(e.capacity(i + 1), sum)
     }
 
     // indices
-    for i in 1..10000000000 {
+    for i in 1..10000000 {
         let (segment, index) = DuT::new().segment_and_offset(i);
         assert!(index < DuT::new().segment_size(segment));
         if index == 0 {


### PR DESCRIPTION
A series of minor cleanup actions in preparation for a new version release.

- Removed the `thin-segments` feature because it made `miri` mad and wasn't very useful.
- Enabled some additional tests that were previously disabled
- (more to come)